### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/test/PhpTabs/BasicsTest.php
+++ b/test/PhpTabs/BasicsTest.php
@@ -25,15 +25,15 @@ class BasicsTest extends TestCase
         $tablature = new PhpTabs();
 
         // Meta attributes
-        $this->assertEquals('', $tablature->getName());
-        $this->assertEquals('', $tablature->getArtist());
-        $this->assertEquals('', $tablature->getAlbum());
-        $this->assertEquals('', $tablature->getAuthor());
-        $this->assertEquals('', $tablature->getCopyright());
-        $this->assertEquals('', $tablature->getWriter());
-        $this->assertEquals('', $tablature->getComments());
-        $this->assertEquals('', $tablature->getDate());
-        $this->assertEquals('', $tablature->getTranscriber());
+        $this->assertNull($tablature->getName());
+        $this->assertNull($tablature->getArtist());
+        $this->assertNull($tablature->getAlbum());
+        $this->assertNull($tablature->getAuthor());
+        $this->assertNull($tablature->getCopyright());
+        $this->assertNull($tablature->getWriter());
+        $this->assertNull($tablature->getComments());
+        $this->assertNull($tablature->getDate());
+        $this->assertNull($tablature->getTranscriber());
 
         // Tracks
         $this->assertEquals(0, $tablature->countTracks());
@@ -50,7 +50,7 @@ class BasicsTest extends TestCase
         // Instruments
         $this->assertEquals(0, $tablature->countInstruments());
         $this->assertEquals(array(), $tablature->getInstruments());
-    
+
         $this->assertInstanceOf('PhpTabs\\Component\\Tablature', $tablature->getTablature());
     }
 
@@ -70,7 +70,7 @@ class BasicsTest extends TestCase
         $this->expectException(Exception::class);
 
         $tablature = new PhpTabs();
-    
+
         $tablature->getTrack(0);
     }
 
@@ -79,7 +79,7 @@ class BasicsTest extends TestCase
         $this->expectException(Exception::class);
 
         $tablature = new PhpTabs();
-    
+
         $tablature->getChannel(0);
     }
 
@@ -88,7 +88,7 @@ class BasicsTest extends TestCase
         $this->expectException(Exception::class);
 
         $tablature = new PhpTabs();
-    
+
         $tablature->getMeasureHeader(0);
     }
 }

--- a/test/PhpTabs/Reader/GuitarPro3ReaderTest.php
+++ b/test/PhpTabs/Reader/GuitarPro3ReaderTest.php
@@ -43,7 +43,7 @@ class GuitarPro3ReaderTest extends TestCase
             $this->tablature->getComments()
         );
         $this->assertEquals('', $this->tablature->getDate());       // Not supported by Guitar Pro 3
-        $this->assertEquals('', $this->tablature->getTranscriber());// Not supported by Guitar Pro 3
+        $this->assertNull($this->tablature->getTranscriber());// Not supported by Guitar Pro 3
 
         // Tracks
         $this->assertEquals(2, $this->tablature->countTracks());

--- a/test/PhpTabs/Reader/GuitarPro4ReaderTest.php
+++ b/test/PhpTabs/Reader/GuitarPro4ReaderTest.php
@@ -40,7 +40,7 @@ class GuitarPro4ReaderTest extends TestCase
             $this->tablature->getComments()
         );
         $this->assertEquals('', $this->tablature->getDate());       // Not supported by Guitar Pro 4
-        $this->assertEquals('', $this->tablature->getTranscriber());// Not supported by Guitar Pro 4
+        $this->assertNull($this->tablature->getTranscriber());// Not supported by Guitar Pro 4
 
         // Tracks
         $this->assertEquals(2, $this->tablature->countTracks());

--- a/test/PhpTabs/Reader/GuitarPro5ReaderTest.php
+++ b/test/PhpTabs/Reader/GuitarPro5ReaderTest.php
@@ -39,7 +39,7 @@ class GuitarPro5ReaderTest extends TestCase
             "Testing comments line 1\nTesting comments line 2",
             $this->tablature->getComments()
         );
-        $this->assertEquals('', $this->tablature->getDate());       // Not supported by Guitar Pro 5
+        $this->assertNull($this->tablature->getDate());       // Not supported by Guitar Pro 5
         $this->assertEquals('', $this->tablature->getTranscriber());// Not supported by Guitar Pro 5
 
         // Tracks

--- a/test/PhpTabs/Reader/MidiReaderTest.php
+++ b/test/PhpTabs/Reader/MidiReaderTest.php
@@ -29,15 +29,15 @@ class MidiReaderTest extends TestCase
     public function testReadModeWithSimpleMidiFile()
     {
         // Meta attributes
-        $this->assertEquals('', $this->tablature->getName());       // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getArtist());     // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getAlbum());      // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getAuthor());     // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getCopyright());  // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getWriter());     // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getComments());   // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getDate());       // Not supported by Midi
-        $this->assertEquals('', $this->tablature->getTranscriber());// Not supported by Midi
+        $this->assertNull($this->tablature->getName());       // Not supported by Midi
+        $this->assertNull($this->tablature->getArtist());     // Not supported by Midi
+        $this->assertNull($this->tablature->getAlbum());      // Not supported by Midi
+        $this->assertNull($this->tablature->getAuthor());     // Not supported by Midi
+        $this->assertNull($this->tablature->getCopyright());  // Not supported by Midi
+        $this->assertNull($this->tablature->getWriter());     // Not supported by Midi
+        $this->assertNull($this->tablature->getComments());   // Not supported by Midi
+        $this->assertNull($this->tablature->getDate());       // Not supported by Midi
+        $this->assertNull($this->tablature->getTranscriber());// Not supported by Midi
 
         // Tracks
         $this->assertEquals(2, $this->tablature->countTracks());
@@ -75,7 +75,7 @@ class MidiReaderTest extends TestCase
         }
 
         $this->assertSame($expected[0], $this->tablature->getInstrument(0));
-    
+
         $this->assertInstanceOf('PhpTabs\\Component\\Tablature', $this->tablature->getTablature());
     }
 


### PR DESCRIPTION
# Changed log

- Removing the useless white spaces.
- Using the `assertNull` to improve assertion and make this expected is `null`.