### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/test/PhpTabs/Component/ExporterTest.php
+++ b/test/PhpTabs/Component/ExporterTest.php
@@ -20,7 +20,7 @@ use PhpTabs\PhpTabs;
  */
 class ExporterTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->tablature = new PhpTabs(
             PHPTABS_TEST_BASEDIR

--- a/test/PhpTabs/Component/FileInputTest.php
+++ b/test/PhpTabs/Component/FileInputTest.php
@@ -17,7 +17,7 @@ use PhpTabs\Component\FileInput;
 
 class FileInputTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename = PHPTABS_TEST_BASEDIR . '/samples/testNotAllowedExtension.xxx';
     }

--- a/test/PhpTabs/Component/ImporterTest.php
+++ b/test/PhpTabs/Component/ImporterTest.php
@@ -20,7 +20,7 @@ use PhpTabs\PhpTabs;
  */
 class ImporterTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->tablature = new PhpTabs(
             PHPTABS_TEST_BASEDIR

--- a/test/PhpTabs/Music/VoiceTest.php
+++ b/test/PhpTabs/Music/VoiceTest.php
@@ -20,7 +20,7 @@ use PhpTabs\IOFactory;
  */
 class VoiceTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->tablature = IOFactory::fromFile(
             PHPTABS_TEST_BASEDIR
@@ -56,7 +56,7 @@ class VoiceTest extends TestCase
         $this->assertEqualsWithDelta(2.0454, $duration, 0.0001);
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Reader/GuitarPro3ReaderTest.php
+++ b/test/PhpTabs/Reader/GuitarPro3ReaderTest.php
@@ -20,7 +20,7 @@ use PhpTabs\PhpTabs;
  */
 class GuitarPro3ReaderTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename = 'testSimpleTab.gp3';
         $this->tablature = new PhpTabs(PHPTABS_TEST_BASEDIR . '/samples/' . $this->filename);
@@ -85,7 +85,7 @@ class GuitarPro3ReaderTest extends TestCase
         $this->assertInstanceOf('PhpTabs\\Component\\Tablature', $this->tablature->getTablature());
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Reader/GuitarPro4ReaderTest.php
+++ b/test/PhpTabs/Reader/GuitarPro4ReaderTest.php
@@ -16,7 +16,7 @@ use PhpTabs\PhpTabs;
 
 class GuitarPro4ReaderTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename = 'testSimpleTab.gp4';
         $this->tablature = new PhpTabs(PHPTABS_TEST_BASEDIR . '/samples/' . $this->filename);
@@ -82,7 +82,7 @@ class GuitarPro4ReaderTest extends TestCase
         $this->assertInstanceOf('PhpTabs\\Component\\Tablature', $this->tablature->getTablature());
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Reader/GuitarPro5ReaderTest.php
+++ b/test/PhpTabs/Reader/GuitarPro5ReaderTest.php
@@ -16,7 +16,7 @@ use PhpTabs\PhpTabs;
 
 class GuitarPro5ReaderTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename = 'testSimpleTab.gp5';
         $this->tablature = new PhpTabs(PHPTABS_TEST_BASEDIR . '/samples/' . $this->filename);
@@ -82,7 +82,7 @@ class GuitarPro5ReaderTest extends TestCase
         $this->assertInstanceOf('PhpTabs\\Component\\Tablature', $this->tablature->getTablature());
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Reader/MidiReaderTest.php
+++ b/test/PhpTabs/Reader/MidiReaderTest.php
@@ -16,7 +16,7 @@ use PhpTabs\PhpTabs;
 
 class MidiReaderTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename = 'testSimpleMidi.mid';
         $this->tablature = new PhpTabs(PHPTABS_TEST_BASEDIR . '/samples/' . $this->filename);
@@ -79,7 +79,7 @@ class MidiReaderTest extends TestCase
         $this->assertInstanceOf('PhpTabs\\Component\\Tablature', $this->tablature->getTablature());
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Renderer/Ascii/AsciiRendererTest.php
+++ b/test/PhpTabs/Renderer/Ascii/AsciiRendererTest.php
@@ -21,7 +21,7 @@ use PhpTabs\IOFactory;
  */
 class AsciiRendererTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename = 'testSimpleTab.gp5';
         $this->tablature = IOFactory::fromFile(
@@ -192,7 +192,7 @@ E|------------------------|-----------------------------------------------------
             ->render(10);
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Renderer/VexTab/VexTabOptionsTest.php
+++ b/test/PhpTabs/Renderer/VexTab/VexTabOptionsTest.php
@@ -20,7 +20,7 @@ use PhpTabs\IOFactory;
  */
 class VexTabOptionsTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename  = 'testSimpleTab.gp3';
         $this->tablature = IOFactory::fromFile(PHPTABS_TEST_BASEDIR . '/samples/' . $this->filename);
@@ -115,7 +115,7 @@ class VexTabOptionsTest extends TestCase
         );
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Renderer/VexTab/VexTabRendererTest.php
+++ b/test/PhpTabs/Renderer/VexTab/VexTabRendererTest.php
@@ -22,7 +22,7 @@ use PhpTabs\Music\Track;
  */
 class VexTabRendererTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->filename = 'testSimpleTab.gp3';
         $this->tablature = new PhpTabs(PHPTABS_TEST_BASEDIR . '/samples/' . $this->filename);
@@ -153,7 +153,7 @@ notes :q 5/2 5d/2 5/2 (5b7b9v/2)u 5/2 5/2 |:q 5/2 :8 5v/2 ## :q 5/2 5/2 5/2 5/2 
             ->render(0);
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Writer/GuitarPro3WriterTest.php
+++ b/test/PhpTabs/Writer/GuitarPro3WriterTest.php
@@ -16,7 +16,7 @@ use PhpTabs\PhpTabs;
 
 class GuitarPro3WriterTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->path = '/samples/testSimpleTab.gp3';
         $this->tablature = new PhpTabs(PHPTABS_TEST_BASEDIR . $this->path);
@@ -42,7 +42,7 @@ class GuitarPro3WriterTest extends TestCase
         );
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Writer/GuitarPro4WriterTest.php
+++ b/test/PhpTabs/Writer/GuitarPro4WriterTest.php
@@ -16,7 +16,7 @@ use PhpTabs\PhpTabs;
 
 class GuitarPro4WriterTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->path = '/samples/testSimpleTab.gp4';
         $this->pathGp3 = '/samples/testSimpleTab.gp3';
@@ -51,7 +51,7 @@ class GuitarPro4WriterTest extends TestCase
         );
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Writer/GuitarPro5WriterTest.php
+++ b/test/PhpTabs/Writer/GuitarPro5WriterTest.php
@@ -16,7 +16,7 @@ use PhpTabs\PhpTabs;
 
 class GuitarPro5WriterTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->path = '/samples/testSimpleTab.gp5';
         $this->pathGp3 = '/samples/testSimpleTab.gp3';
@@ -59,7 +59,7 @@ class GuitarPro5WriterTest extends TestCase
         );
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }

--- a/test/PhpTabs/Writer/MidiWriterTest.php
+++ b/test/PhpTabs/Writer/MidiWriterTest.php
@@ -23,7 +23,7 @@ use PhpTabs\PhpTabs;
  */
 class MidiWriterTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->path = '/files/midi/minimal.gp5';
         $this->midi = '/files/midi/minimal.mid';
@@ -44,7 +44,7 @@ class MidiWriterTest extends TestCase
         );
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         unset($this->tablature);
     }


### PR DESCRIPTION
# Changed log

- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.