### PR TITLE
Add XDEBUG_MODE=coverage for executing PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
     - chmod +x ./cc-test-reporter 
     - ./cc-test-reporter before-build
 
-script: ./vendor/bin/phpunit -c phpunit.xml.dist
+script: XDEBUG_MODE=coverage ./vendor/bin/phpunit -c phpunit.xml.dist
 
 after_script:
     ## Code climate


### PR DESCRIPTION
# Changed log

- Adding the `XDEBUG_MODE=coverage` to fix warning message:

```
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set
```